### PR TITLE
Update the config.json example

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -17,7 +17,7 @@ The full config.json should be something like that:
 .. code-block:: javascript
 
     {
-        "config.docxFile":"input.docx",
+        "config.inputFile":"input.docx",
         "config.outputFile":"output.docx",
         "config.qrcode":true,
         "config.debug":true,


### PR DESCRIPTION
"config.docxFile":"input.docx" will throw an error in the latest version.

The correct way is "config.inputFile":"input.docx"