### PR TITLE
Allow same tags as start and end delimiters

### DIFF
--- a/coffee/docxgenTest.coffee
+++ b/coffee/docxgenTest.coffee
@@ -604,6 +604,19 @@ startTest=->
 				start:'{'
 				end:'}'
 
+		it 'should work with custom tags, same for start and end', () ->
+			DocUtils.tags=
+				start:'@'
+				end:'@'
+			content= """<w:t>Hello @name@</w:t>"""
+			scope= {"name":"Edgar"}
+			xmlTemplater= new DocXTemplater(content,{Tags:scope})
+			xmlTemplater.render()
+			expect(xmlTemplater.getFullText()).toBe('Hello Edgar')
+			DocUtils.tags=
+				start:'{'
+				end:'}'
+
 		it 'should work with loops', ()->
 			content="{innertag</w:t><w:t>}"
 			xmlt=new DocXTemplater(content,{Tags:{innertag:5}}).render()

--- a/coffee/xmlTemplater.coffee
+++ b/coffee/xmlTemplater.coffee
@@ -73,10 +73,11 @@ module.exports=class XmlTemplater #abstract class !!
 						console.error @content
 						console.error m[0]
 						throw new Error("no < at the beginning of #{m[0][0]} (2)")
-				if trail == DocUtils.tags.start
+				@sameTags = DocUtils.tags.start == DocUtils.tags.end
+				if (@sameTags is true and @templaterState.inTag is false and trail == DocUtils.tags.start) or (@sameTags is false and trail == DocUtils.tags.start)
 					@templaterState.currentStep=trailSteps[0]
 					@templaterState.startTag()
-				else if trail == DocUtils.tags.end
+				else if (@sameTags is true and @templaterState.inTag is true and trail == DocUtils.tags.end) or (@sameTags is false and trail == DocUtils.tags.end)
 					@templaterState.endTag()
 					loopType=@templaterState.loopType()
 					if loopType=='simple'


### PR DESCRIPTION
The custom tags feature should allow using the same string for both start and end delimiters.
Tests are passing, plus a new test checking for the new feature.

See https://github.com/edi9999/docxtemplater/issues/111#issuecomment-70812391